### PR TITLE
Clarify that only elements with opaque background color contribute to NBG(R_i) 

### DIFF
--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -410,7 +410,12 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
 
       <p class="note">An element and its parent that satisfy the criteria above and share identical computed values 
         of <code>tts:backgroundColor</code> are counted as two distinct elements for the purpose of computing NBG(R<sub>i</sub>).</p>
-    </section>
+
+      <p class="note">The <code>set</code> element is not included in the computation of NBG(R<sub>i</sub>). While it can affect the
+      computed values of <code>tts:backgroundColor</code>, it is removed during <a>Intermediate Synchronic Document</a>
+      construction.</p>
+  
+      </section>
 
     <section id='paint-images'>
       <h2>Paint Images</h2>

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -399,28 +399,17 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         <code>tts:extent="1920px 1080px"</code>, NSIZE(R<sub>i</sub>) ≈ 0.00603.
       </aside>
 
-      <p>NBG(R<sub>i</sub>) SHALL be the total number of <code>tts:backgroundColor</code> attributes associated with the given
-        region R<sub>i</sub> in the <a>intermediate synchronic document</a>. A <code>tts:backgroundColor</code> attribute is
-        associated with a region when it is explicitly specified (either as an attribute in the element, or by reference to a
-        declared style) in the following circumstances:</p>
-  
-        <ul>
-          <li>it is specified on the <code>region</code> layout element that defines the region; or</li>
-  
-          <li>it is specified on a <code>div</code>, <code>p</code>, <code>span</code> or <code>br</code> content element that is to
-          be flowed into the region for presentation in the <a>intermediate synchronic document</a> (see [[!ttml2]] for more details
-          on when a content element is followed into a region); or
-          </li>
-  
-          <li>it is specified on a <code>set</code> animation element that is to be applied to content elements that are to be flowed
-          into the region for presentation in the <a>intermediate synchronic document</a> (see [[!ttml2]] for more details on when a
-          <code>set</code> animation element is applied to content elements).
-          </li>
-        </ul>
-  
-        <p>Even if a specified <code>tts:backgroundColor</code> is the same as specified on the nearest ancestor content element or
-        animation element, specifying any <code>tts:backgroundColor</code> SHALL require an additional fill operation for all region
-        pixels.</p>
+      <p>NBG(R<sub>i</sub>) SHALL be the total number of elements within the tree rooted at region R<sub>i</sub> that satisfy the following criteria:</p>
+
+      <ul>
+        <li>the element is either a <code>region</code>, <code>body</code>, <code>div</code>, <code>p</code>, 
+           <code>span</code> or  <code>br</code>; and</li>
+
+        <li>the opacity of the computed value of <code>tts:backgroundColor</code> is not <code>0</code>.</li>
+      </ul>
+
+      <p class="note">An element and its parent that satisfy the criteria above and share identical computed values 
+        of <code>tts:backgroundColor</code> are counted as two distinct elements for the purpose of computing NBG(R<sub>i</sub>).</p>
     </section>
 
     <section id='paint-images'>

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -402,8 +402,8 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p>NBG(R<sub>i</sub>) SHALL be the total number of elements within the tree rooted at region R<sub>i</sub> that satisfy the following criteria:</p>
 
       <ul>
-        <li>the element is either a <code>region</code>, <code>body</code>, <code>div</code>, <code>p</code>, 
-           <code>span</code> or  <code>br</code>; and</li>
+        <li>the element is either a <code>region</code>, <code>body</code>, <code>div</code>, <code>p</code> or 
+           <code>span</code>; and</li>
 
         <li>the opacity of the computed value of <code>tts:backgroundColor</code> is not <code>0</code>.</li>
       </ul>


### PR DESCRIPTION
Closes #2 
Closes #4 
Closes #3 

Replaces https://github.com/w3c/imsc/pull/572


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/pull/7.html" title="Last updated on Sep 26, 2021, 10:42 PM UTC (27e45f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/7/129d887...27e45f9.html" title="Last updated on Sep 26, 2021, 10:42 PM UTC (27e45f9)">Diff</a>