### PR TITLE
added section of terminology in IMSC spec

### DIFF
--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -216,22 +216,22 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
 
   <section id='terms'>
     <h2>Terms and Definitions</h2>
-    <p><dfn data-lt="Document Instance|Document Instances">Document Instance</dfn>. See Section 2.2 at [[!ttml2]].</p>
+    <p><dfn data-lt="Document Instance|Document Instances">Document Instance</dfn>. See [[!ttml2]].</p>
 
     <p><dfn>IMSC Document Instance</dfn>. A <a>Document Instance</a> that conforms to any profile defined in any edition of
     [[!imsc]].</p>
 
-    <p><dfn>Intermediate Synchronic Document</dfn>. See Section 9.3.2 at [[!ttml2]].</p>
-    <p><dfn>Root Container Region</dfn>. See Section 2.2 at [[!ttml2]].</p>
+    <p><dfn>Intermediate Synchronic Document</dfn>. See [[!ttml2]].</p>
+    <p><dfn>Root Container Region</dfn>. See [[!ttml2]].</p>
 
     <p><dfn>Related Video Object</dfn>. A <a>Related Media Object</a> that consists of a sequence of image frames, each a
       rectangular array of pixels.</p>
 
-      <p><dfn>Related Media Object</dfn>. See Section 2.2 at [[!ttml2]].</p>
+      <p><dfn>Related Media Object</dfn>. See [[!ttml2]].</p>
 
-      <p><dfn>presented region</dfn>. See Section 8.12.1.1 at [[!imsc]].</p>
+      <p><dfn>presented region</dfn>. See [[!imsc]].</p>
 
-      <p><dfn>presented image</dfn>. See Section 10.2 at [[!imsc]].</p>
+      <p><dfn>presented image</dfn>. See [[!imsc]].</p>
       
       <p><dfn>empty ISD</dfn>. an <a>Intermediate Synchronic Document</a> with no <a>presented region</a>.</p>
   </section>

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -229,9 +229,9 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
 
       <p><dfn>Related Media Object</dfn>. See Section 2.2 at [[!ttml2]].</p>
 
-      <p><dfn>presented region</dfn>. See [[!imsc]].</p>
+      <p><dfn>presented region</dfn>. See Section 8.12.1.1 at [[!imsc]].</p>
 
-      <p><dfn>presented image</dfn>. See [[!imsc]].</p>
+      <p><dfn>presented image</dfn>. See Section 10.2 at [[!imsc]].</p>
       
       <p><dfn>empty ISD</dfn>. an <a>Intermediate Synchronic Document</a> with no <a>presented region</a>.</p>
   </section>


### PR DESCRIPTION
Seems two terminologies lack sections to cite?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/imsc-hrm/pull/16.html" title="Last updated on Dec 9, 2021, 4:51 PM UTC (ad8dafe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/16/dded30b...himorin:ad8dafe.html" title="Last updated on Dec 9, 2021, 4:51 PM UTC (ad8dafe)">Diff</a>