### PR TITLE
fixed HTML syntax for sub

### DIFF
--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -411,7 +411,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p class="equation">PAINT(E<sub>n</sub>) = ∑<sub>R<sub>i</sub>∈R<sub>p</sub></sub> NSIZE(R<sub>i</sub>) ∙
       NBG(R<sub>i</sub>)</p>
 
-      <p>where R_p SHALL be the set of <a data-lt="presented region">presented regions</a> in the <a>intermediate synchronic
+      <p>where R<sub>p</sub> SHALL be the set of <a data-lt="presented region">presented regions</a> in the <a>intermediate synchronic
       document</a> E<sub>n</sub>.</p>
 
       <p>NSIZE(R<sub>i</sub>) SHALL be given by:</p>


### PR DESCRIPTION
as title.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/imsc-hrm/pull/25.html" title="Last updated on Dec 14, 2021, 7:55 AM UTC (3286009)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/25/3a33509...himorin:3286009.html" title="Last updated on Dec 14, 2021, 7:55 AM UTC (3286009)">Diff</a>