### PR TITLE
Use better terms than character

### DIFF
--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -566,14 +566,18 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p class='note'>In the case where a property is <em>prohibited</em> in a profile of [[IMSC]], the computed value of the property
       specified in [[ttml2]] can be used.</p>
 
-      <p class='note'>While one-to-one mapping between <a>characters</a> and glyphs (as defined in [[i18n-glossary]])
-      is common in some scripts (such as the Latin script), the actual relationship is often more complex.
-      Some scripts, such as Arabic, use different glyphs for a given <a>code point</a> depending on its position in a word.
+      <p class='note'>The Hypothetical Render Model defines a one-to-one mapping between <a>characters</a> and <a>glyphs</a>
+      (using the definition of glyph from this document).
+      While a one-to-one mapping between <a>code points</a> and glyphs (using the definition of glyph from [[i18n-glossary]])
+      is common in some scripts (such as the Latin script),
+      the actual relationship is more complex.
+      Some scripts, such as Arabic, use different glyphs for a given character,
+      depending on its position in a word.
       Some scripts require combining marks or use a sequence of code points to form a glyph.
       Cases exist where a given sequence of code points can have different glyph representations depending on context.
-      The Hypothetical Render Model assumes that code points have a one-to-one mapping to a glyph,
-      but accounts for the above complexity by reducing the performance of the glyph buffer
-      for scripts where a one-to-one mapping is not the general rule (see GCpy below).</p>
+      This complexity is accounted for by reducing the performance of the glyph buffer
+      for scripts where a one-to-one mapping is not the general rule (see GCpy below).
+      </p>
 
       <p>For each <a>glyph</a> associated with a <a>character</a> in a <a>presented region</a> of <a>Intermediate Synchronic Document</a>
       E<sub>n</sub>, the Presentation Compositor SHALL:</p>


### PR DESCRIPTION
Also improve note about mapping between code points and glyphs, and make reference to the i18n glossary for otherwise undefined terms.

Closes #36.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/pull/42.html" title="Last updated on Mar 16, 2022, 11:29 AM UTC (14538bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/42/9896b42...14538bb.html" title="Last updated on Mar 16, 2022, 11:29 AM UTC (14538bb)">Diff</a>