### PR TITLE
Replace CJK block with list of scripts for the text rendering performance factor

### DIFF
--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -657,13 +657,14 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
           </tr>
 
           <tr>
-            <td style="text-align: center;"><em>Block property (see [[!UNICODE]]) for the character of g<sub>i</sub></em></td>
+            <td style="text-align: center;"><em>Script property (see Standard Annex #24 at [[!UNICODE]]) for the character of
+            g<sub>i</sub></em></td>
 
             <td style="text-align: center;"><em>Ren(G<sub>i</sub>)</em></td>
           </tr>
 
           <tr>
-            <td>CJK Unified Ideograph</td>
+            <td><code>Han</code>, <code>Katakana</code>, <code>Hiragana</code>, <code>Bopomofo</code> or <code>Hangul</code></td>
 
             <td style="text-align: center;">0.6</td>
           </tr>

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -657,7 +657,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
           </tr>
 
           <tr>
-            <td style="text-align: center;"><em>Script property (see Standard Annex #24 at [[!UNICODE]]) for the character of
+            <td style="text-align: center;"><em>Script property, as defined at [[!UAX24]], for the character of
             g<sub>i</sub></em></td>
 
             <td style="text-align: center;"><em>Ren(G<sub>i</sub>)</em></td>


### PR DESCRIPTION
Closes #38


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/pull/44.html" title="Last updated on Mar 7, 2022, 4:35 PM UTC (f214f88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/44/de9252b...f214f88.html" title="Last updated on Mar 7, 2022, 4:35 PM UTC (f214f88)">Diff</a>