### PR TITLE
Clarify that the IMSC HRM specifies document conformance

### DIFF
--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -252,9 +252,13 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
     </p>
     <p class="note">Applying the Hypothetical Render Model to a <a>Document Instance</a> that is not an <a>IMSC Document
     Instance</a> yields results that might not reflect the complexity of the <a>Document Instance</a>.</p>
-    <p class="note">Conformance can be applied to a sequence of <a>Document Instances</a> by constructing a single
-    <a>Document Instance</a> whose underlying sequence of <a>Intermediate Synchronic Documents</a> is identical to that
-    resulting from the sequence of <a>Document Instances</a>.</p>
+    <p class="note">In applications where sequences of <a>Document Instances</a>
+    can be resolved into a single sequence of <a>Intermediate Synchronic Documents</a>
+    that do not overlap each other temporally,
+    conformance can be determined based on a synthesised <a>Document Instance</a>
+    that generates an equivalent sequence of <a>Intermediate Synchronic Documents</a>,
+    where minimal equivalence is limited to the content and metrics that are used
+    to identify <a>errors</a>.</p>
   </section>
 
   <section class="informative">

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -227,7 +227,8 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
 
       <p><dfn data-lt="code point|code points">code point</dfn>. As defined by [[i18n-glossary]].</p>
 
-      <p><dfn>empty ISD</dfn>. An <a>Intermediate Synchronic Document</a> with no <dfn
+      <p><dfn>empty ISD</dfn>. An <dfn
+        data-cite="ttml2#terms-intermediate-synchronic-document">Intermediate Synchronic Document</dfn> with no <dfn
       data-cite="IMSC#dfn-presented-region">presented region</dfn>.</p>
 
       <p><dfn>non-empty ISD</dfn>. An <a>Intermediate Synchronic Document</a> with at least one <a>presented region</a>.</p>
@@ -244,14 +245,16 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       Unless noted otherwise, this specification applies to an <a>IMSC Document Instance</a>.
     </p>
     <p>
-      Given a sequence of consecutive <dfn data-cite="ttml2#terms-intermediate-synchronic-document">Intermediate
-      Synchronic Documents</dfn> generated using the <i>Intermediate Synchronic Document Construction</i> procedure
-      specified in [[!TTML2]] from one or more input <a>IMSC Document Instances</a>, the sequence of
-      <a>Intermediate Synchronic Documents</a> <i>conforms to the Hypothetical Render Model</i> SHALL be processed
-      without <a>error</a> by the HRM algorithm specified at <a href="#hypothetical-render-model-general"></a>.
+      A <a>IMSC Document Instance</a> <i>conforms to the Hypothetical Render Model</i> if the sequence of
+      <a>Intermediate Synchronic Documents</a> generated from it using the <i>Intermediate Synchronic Document
+      Construction</i> procedure specified in [[!TTML2]] is processed without <a>error</a> by the HRM algorithm
+      specified at <a href="#hypothetical-render-model-general"></a>.
     </p>
     <p class="note">Applying the Hypothetical Render Model to a <a>Document Instance</a> that is not an <a>IMSC Document
     Instance</a> yields results that might not reflect the complexity of the <a>Document Instance</a>.</p>
+    <p class="note">Conformance can be applied to a sequence of <a>Document Instances</a> by constructing a single
+    <a>Document Instance</a> whose underlying sequence of <a>Intermediate Synchronic Documents</a> is identical to that
+    resulting from the sequence of <a>Document Instances</a>.</p>
   </section>
 
   <section class="informative">
@@ -425,8 +428,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       </figure>
 
       <p>The HRM, illustrated in <a href="#fig-hypothetical-render-model"></a>, operates on a sequence of
-      <a>Intermediate Synchronic Documents</a> E<sub>i</sub> generated using the <i>Intermediate Synchronic Document
-      Construction</i> procedure specified in [[!TTML2]] from one or more input <a>IMSC Document Instances</a>:</p>
+      <a>Intermediate Synchronic Documents</a> E<sub>i</sub>:</p>
       <ul>
         <li><a>non-empty ISDs</a> are processed using a simple double buffering model: while a <a>non-empty ISD</a>
         E<sub>n</sub> is being painted into a Back Buffer, the previous <a>non-empty ISD</a> E<sub>m</sub> is available
@@ -545,7 +547,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       example, if the Back Buffer is copied twice to Front Buffer between two consecutive video frame boundaries of the
       <a>Related Video Object</a>.</p>
 
-      <p>It is an <a>error</a> for the Presentation Compositor to fail to complete painting pixels for
+      <p>It SHALL be an <a>error</a> for the Presentation Compositor to fail to complete painting pixels for
       <a>non-empty ISD</a> E<sub>n</sub> before its presentation time.</p>
 
       <p>The following table specifies the values of <a>IPD</a> and BDraw.</p>
@@ -825,8 +827,8 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p>The contents of the Glyph Buffer G<sub>n</sub> are copied instantaneously to Glyph Buffer G<sub>n-1</sub> at the
       presentation time of <a>Intermediate Synchronic Document</a> E<sub>n</sub>.</p>
 
-      <p>It is an <a>error</a> for the sum of NRGA(g<sub>i</sub>) over all <a data-lt="glyph">glyphs</a> Glyph Buffer G<sub>n</sub>
-      to be larger than the Normalized Glyph Buffer Size (NGBS).</p>
+      <p>It SHALL be an <a>error</a> for the sum of NRGA(g<sub>i</sub>) over all <a data-lt="glyph">glyphs</a> Glyph
+      Buffer G<sub>n</sub> to be larger than the Normalized Glyph Buffer Size (NGBS).</p>
 
       <p>Unless specified otherwise, the following table specifies values of GCpy, Ren and NGBS.</p>
 

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -245,7 +245,8 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
     </p>
     <p>
       A sequence of consecutive <dfn data-cite="ttml2#terms-intermediate-synchronic-document">Intermediate Synchronic Documents</dfn>
-      conforms to the Hypothetical Render Model if is processed without <a>error</a>.
+      that <i>conforms to the Hypothetical Render Model</i> SHALL be processed without <a>error</a> by the HRM algorithm
+      specified at <a href="#hypothetical-render-model-general"></a>.
     </p>
     <p class="note">Applying the Hypothetical Render Model to a <a>Document Instance</a> that is not an <a>IMSC Document
     Instance</a> yields results that might not reflect the complexity of the <a>Document Instance</a>.</p>
@@ -346,7 +347,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
           <a>characters</a> that are then presented for over 59 seconds. This generates a
           high rendering complexity for the 835 <a>characters</a>, since there is only a
           brief time available to paint them.</p>
-        <p>In the second, 210 <a>characters</a> must be
+        <p>In the second, 210 <a>characters</a> are be
           painted every 15 seconds, giving 15 seconds to prepare for the next
           presentation. This has a much lower rendering complexity.</p>
       </div>
@@ -421,7 +422,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         </figcaption>
       </figure>
 
-      <p>The model illustrated in <a href="#fig-hypothetical-render-model"></a> operates on successive
+      <p>The HRM, illustrated in <a href="#fig-hypothetical-render-model"></a>, operates on successive
       <a>Intermediate Synchronic Documents</a> E<sub>i</sub> obtained from an input <a>IMSC Document Instance</a>:</p>
       <ul>
         <li><a>non-empty ISDs</a> are processed using a simple double buffering model: while a <a>non-empty ISD</a>
@@ -457,10 +458,12 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
     </section>
 
     <section id='hypothetical-render-model-general'>
-      <h2>General</h2>
+      <h2>Algorithm</h2>
 
-      <p>The Presentation Compositor SHALL render in the Back Buffer each successive <a>non-empty
-      ISD</a> E<sub>n</sub> using the following steps in order:</p>
+      <p>The HRM algorithm processes a sequence of <a>Intermediate Synchronic Documents</a> E<sub>n</sub>.</p>
+
+      <p>Each successive <a>non-empty ISD</a> E<sub>n</sub> is rendered by the Presentation Compositor using the
+      following steps in order:</p>
 
       <ol>
         <li>clear the pixels of the entire <a>Root Container Region</a>;</li>
@@ -472,7 +475,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         <li>paint the text or image subtitle content.</li>
       </ol>
 
-      <p>The Presentation Compositor SHALL start rendering E<sub>n</sub>:</p>
+      <p>The Presentation Compositor starts rendering E<sub>n</sub>:</p>
 
       <ul>
         <li>at the presentation time of E<sub>m</sub>, where m is the largest non-zero value that is both less than
@@ -503,7 +506,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       </figure>
 
       <p>The duration DUR(E<sub>n</sub>) for painting an <a>Intermediate Synchronic Document</a> E<sub>n</sub> in the
-      Back Buffer SHALL be:</p>
+      Back Buffer is given by:</p>
 
       <p class="equation">DUR(E<sub>n</sub>) = S(E<sub>n</sub>) / BDraw + DUR<sub>T</sub>(E<sub>n</sub>) +
       DUR<sub>I</sub>(E<sub>n</sub>)</p>
@@ -526,10 +529,10 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         </li>
       </ul>
 
-      <p>The contents of the Back Buffer SHALL be transferred instantaneously to the Front Buffer at the presentation
+      <p>The contents of the Back Buffer are transferred instantaneously to the Front Buffer at the presentation
       time of a <a>non-empty ISD</a> E<sub>n</sub>, making the latter available for display.</p>
 
-      <p>The Front Buffer SHALL be:</p>
+      <p>The Front Buffer is:</p>
       <ul>
         <li>disconnected from the display while an <a>empty ISD</a> is being presented; and</li>
         <li>connected to the display, otherwise.</li>
@@ -539,10 +542,10 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       example, if the Back Buffer is copied twice to Front Buffer between two consecutive video frame boundaries of the
       <a>Related Video Object</a>.</p>
 
-      <p>It SHALL be an <a>error</a> for the Presentation Compositor to fail to complete painting pixels for
+      <p>It is an <a>error</a> for the Presentation Compositor to fail to complete painting pixels for
       <a>non-empty ISD</a> E<sub>n</sub> before its presentation time.</p>
 
-      <p>Unless specified otherwise, the following table SHALL specify values for <a>IPD</a> and BDraw.</p>
+      <p>The following table specifies values for <a>IPD</a> and BDraw.</p>
 
       <table class='simple'>
         <thead>
@@ -578,7 +581,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
     <section id='paint-regions'>
       <h2>Paint Regions</h2>
 
-      <p>The total normalized drawing area S(E<sub>n</sub>) for <a>Intermediate Synchronic Document</a> E<sub>n</sub> SHALL be</p>
+      <p>The total normalized drawing area S(E<sub>n</sub>) for <a>Intermediate Synchronic Document</a> E<sub>n</sub> is given by:</p>
 
       <p class="equation">S(E<sub>n</sub>) = CLEAR(E<sub>n</sub>) + PAINT(E<sub>n</sub> )</p>
 
@@ -587,16 +590,16 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p class='note'>To ensure consistency of the Back Buffer, a new <a>Intermediate Synchronic Document</a> requires
       clearing of the <a>Root Container Region</a>.</p>
 
-      <p>PAINT(E<sub>n</sub>) SHALL be the normalized area to be painted for all regions that are used in <a>Intermediate
+      <p>PAINT(E<sub>n</sub>) is the normalized area to be painted for all regions that are used in <a>Intermediate
       Synchronic Document</a> E<sub>n</sub> according to:</p>
 
       <p class="equation">PAINT(E<sub>n</sub>) = ∑<sub>R<sub>i</sub>∈R<sub>p</sub></sub> NSIZE(R<sub>i</sub>) ∙
       NBG(R<sub>i</sub>)</p>
 
-      <p>where R<sub>p</sub> SHALL be the set of <a data-lt="presented region">presented regions</a> in the <a>Intermediate Synchronic
+      <p>where R<sub>p</sub> is the set of <a data-lt="presented region">presented regions</a> in the <a>Intermediate Synchronic
       Document</a> E<sub>n</sub>.</p>
 
-      <p>NSIZE(R<sub>i</sub>) SHALL be given by:</p>
+      <p>NSIZE(R<sub>i</sub>) is given by:</p>
 
       <p class="equation">NSIZE(R<sub>i</sub>) = (width of R<sub>i</sub> ∙ height of R<sub>i</sub> ) ÷ (<a>Root Container
       Region</a> height ∙ <a>Root Container Region</a> width)</p>
@@ -606,7 +609,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         <code>tts:extent="1920px 1080px"</code>, NSIZE(R<sub>i</sub>) ≈ 0.00603.
       </aside>
 
-      <p>NBG(R<sub>i</sub>) SHALL be the total number of elements within the tree rooted at region R<sub>i</sub> that satisfy the following criteria:</p>
+      <p>NBG(R<sub>i</sub>) is the total number of elements within the tree rooted at region R<sub>i</sub> that satisfy the following criteria:</p>
 
       <ul>
         <li>the element is either a <code>region</code>, <code>body</code>, <code>div</code>, <code>p</code> or 
@@ -629,17 +632,17 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
     <section id='paint-images'>
       <h2>Paint Images</h2>
 
-      <p>The Presentation Compositor SHALL paint into the Back Buffer all visible pixels of <a>presented
+      <p>The Presentation Compositor paints into the Back Buffer all visible pixels of <a>presented
       images</a> of <a>Intermediate Synchronic Document</a> E<sub>n</sub>.</p>
 
-      <p>For each <dfn data-cite="IMSC#dfn-presented-image">presented image</dfn>, the Presentation Compositor SHALL either:</p>
+      <p>For each <dfn data-cite="IMSC#dfn-presented-image">presented image</dfn>, the Presentation Compositor either:</p>
 
       <ul>
-        <li>if an identical image is present in Decoded Image Buffer D<sub>n</sub>, copy the image from Decoded Image Buffer
+        <li>if an identical image is present in Decoded Image Buffer D<sub>n</sub>, copies the image from Decoded Image Buffer
         D<sub>n</sub> to the Back Buffer using the Image Copier; or</li>
 
         <li>if an identical image is present in Decoded Image Buffer D<sub>n-1</sub>, i.e. an identical image was present in
-        <a>Intermediate Synchronic Document</a> E<sub>n-1</sub>, copy using the Image Copier the image from Decoded Image Buffer
+        <a>Intermediate Synchronic Document</a> E<sub>n-1</sub>, copies using the Image Copier the image from Decoded Image Buffer
         D<sub>n-1</sub> to both the Decoded Image Buffer D<sub>n</sub> and the Back Buffer; or
         </li>
 
@@ -647,10 +650,10 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         Image Buffer D<sub>n</sub>.</li>
       </ul>
 
-      <p>Two images SHALL be identical if and only if they reference the same encoded image source.</p>
+      <p>Two images are identical if and only if they reference the same encoded image source.</p>
 
       <p>The duration DUR<sub>I</sub>(E<sub>n</sub>) for painting images of an <a>Intermediate Synchronic Document</a>
-      E<sub>n</sub> in the Back Buffer SHALL be as follows:</p>
+      E<sub>n</sub> in the Back Buffer is given by:</p>
 
       <p class="equation">DUR<sub>I</sub>(E<sub>n</sub>) = ∑<sub>I<sub>i</sub> ∈ I<sub>c</sub></sub> NRGA(I<sub>i</sub>) / ICpy
       + ∑<sub>I<sub>j</sub> ∈ I<sub>d</sub></sub> NSIZ(I<sub>j</sub>) / IDec</p>
@@ -669,23 +672,23 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         <li>ICpy is the normalized image copy performance factor.</li>
       </ul>
 
-      <p>NRGA(I<sub>i</sub>) is the Normalized Image Area of <a>presented image</a> I<sub>i</sub> and SHALL be equal to:</p>
+      <p>NRGA(I<sub>i</sub>) is the Normalized Image Area of <a>presented image</a> I<sub>i</sub> and is given by:</p>
 
       <p class="equation">NRGA(I<sub>i</sub>)= (width of I<sub>i</sub> ∙ height of I<sub>i</sub> ) ÷ ( <a>Root Container
       Region</a> height ∙ <a>Root Container Region</a> width )</p>
 
-      <p>NSIZ(I<sub>i</sub>) SHALL be the number of pixels of <a>presented image</a> I<sub>i</sub>.</p>
+      <p>NSIZ(I<sub>i</sub>) is the number of pixels of <a>presented image</a> I<sub>i</sub>.</p>
 
-      <p>The contents of the Decoded Image Buffer D<sub>n</sub> SHALL be transferred instantaneously to Decoded Image Buffer
+      <p>The contents of the Decoded Image Buffer D<sub>n</sub> are transferred instantaneously to Decoded Image Buffer
       D<sub>n-1</sub> at the presentation time of <a>Intermediate Synchronic Document</a> E<sub>n</sub>.</p>
 
-      <p>The total size occupied by images stored in Decoded Image Buffers D<sub>n</sub> or D<sub>n-1</sub> SHALL be the sum of
+      <p>The total size occupied by images stored in Decoded Image Buffers D<sub>n</sub> or D<sub>n-1</sub> is the sum of
       their Normalized Image Area.</p>
 
-      <p>The size of Decoded Image Buffers D<sub>n</sub> or D<sub>n-1</sub> SHALL be the Normalized Decoded Image Buffer Size
+      <p>The size of Decoded Image Buffers D<sub>n</sub> or D<sub>n-1</sub> is the Normalized Decoded Image Buffer Size
       (NDIBS).</p>
 
-      <p>Unless specified otherwise, the following table SHALL specify ICpy, IDec, and NDBIS.</p>
+      <p>The following table specifies ICpy, IDec, and NDBIS.</p>
 
       <table class='simple'>
         <thead>
@@ -759,15 +762,15 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       </p>
 
       <p>For each <a>glyph</a> associated with a <a>character</a> in a <a>presented region</a> of <a>Intermediate Synchronic Document</a>
-      E<sub>n</sub>, the Presentation Compositor SHALL:</p>
+      E<sub>n</sub>, the Presentation Compositor:</p>
 
       <ul>
-        <li>if an identical <a>glyph</a> is present in Glyph Buffer G<sub>n</sub>, copy the <a>glyph</a> from Glyph Buffer
+        <li>if an identical <a>glyph</a> is present in Glyph Buffer G<sub>n</sub>, copies the <a>glyph</a> from Glyph Buffer
         G<sub>n</sub> to the Back Buffer using the Glyph Copier; or
         </li>
 
         <li>if an identical <a>glyph</a> is present in Glyph Buffer G<sub>n-1</sub>, i.e. an identical <a>glyph</a> was present in
-        <a>Intermediate Synchronic Document</a> E<sub>n-1</sub>, copy using the Glyph Copier the <a>glyph</a> from Glyph Buffer
+        <a>Intermediate Synchronic Document</a> E<sub>n-1</sub>, copies using the Glyph Copier the <a>glyph</a> from Glyph Buffer
         G<sub>n-1</sub> to both the Glyph Buffer G<sub>n</sub> and the Back Buffer; or
         </li>
 
@@ -807,7 +810,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         <li>GCpy is the normalized glyph copy performance factor.</li>
       </ul>
 
-      <p>The Normalized Rendered Glyph Area NRGA(g<sub>i</sub>) of a <a>glyph</a> g<sub>i</sub> SHALL be equal to:</p>
+      <p>The Normalized Rendered Glyph Area NRGA(g<sub>i</sub>) of a <a>glyph</a> g<sub>i</sub> is given by:</p>
 
       <p class="equation">NRGA(g<sub>i</sub>) = (fontSize of g<sub>i</sub> as percentage of <a>Root Container Region</a>
       height)<sup>2</sup></p>
@@ -816,10 +819,10 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       typographical glyph aspect ratio. An implementation can determine an actual buffer size needs based on worst-case glyph size
       complexity.</p>
 
-      <p>The contents of the Glyph Buffer G<sub>n</sub> SHALL be copied instantaneously to Glyph Buffer G<sub>n-1</sub> at the
+      <p>The contents of the Glyph Buffer G<sub>n</sub> is copied instantaneously to Glyph Buffer G<sub>n-1</sub> at the
       presentation time of <a>Intermediate Synchronic Document</a> E<sub>n</sub>.</p>
 
-      <p>It SHALL be an <a>error</a> for the sum of NRGA(g<sub>i</sub>) over all <a data-lt="glyph">glyphs</a> Glyph Buffer G<sub>n</sub>
+      <p>It is an <a>error</a> for the sum of NRGA(g<sub>i</sub>) over all <a data-lt="glyph">glyphs</a> Glyph Buffer G<sub>n</sub>
       to be larger than the Normalized Glyph Buffer Size (NGBS).</p>
 
       <p>Unless specified otherwise, the following table specifies values of GCpy, Ren and NGBS.</p>

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -244,9 +244,11 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       Unless noted otherwise, this specification applies to an <a>IMSC Document Instance</a>.
     </p>
     <p>
-      A sequence of consecutive <dfn data-cite="ttml2#terms-intermediate-synchronic-document">Intermediate Synchronic Documents</dfn>
-      that <i>conforms to the Hypothetical Render Model</i> SHALL be processed without <a>error</a> by the HRM algorithm
-      specified at <a href="#hypothetical-render-model-general"></a>.
+      Given a sequence of consecutive <dfn data-cite="ttml2#terms-intermediate-synchronic-document">Intermediate
+      Synchronic Documents</dfn> generated using the <i>Intermediate Synchronic Document Construction</i> procedure
+      specified in [[!TTML2]] from one or more input <a>IMSC Document Instances</a>, the sequence of
+      <dfn>Intermediate Synchronic Documents</dfn> <i>conforms to the Hypothetical Render Model</i> SHALL be processed
+      without <a>error</a> by the HRM algorithm specified at <a href="#hypothetical-render-model-general"></a>.
     </p>
     <p class="note">Applying the Hypothetical Render Model to a <a>Document Instance</a> that is not an <a>IMSC Document
     Instance</a> yields results that might not reflect the complexity of the <a>Document Instance</a>.</p>
@@ -347,7 +349,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
           <a>characters</a> that are then presented for over 59 seconds. This generates a
           high rendering complexity for the 835 <a>characters</a>, since there is only a
           brief time available to paint them.</p>
-        <p>In the second, 210 <a>characters</a> are be
+        <p>In the second, 210 <a>characters</a> are
           painted every 15 seconds, giving 15 seconds to prepare for the next
           presentation. This has a much lower rendering complexity.</p>
       </div>
@@ -422,8 +424,9 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         </figcaption>
       </figure>
 
-      <p>The HRM, illustrated in <a href="#fig-hypothetical-render-model"></a>, operates on successive
-      <a>Intermediate Synchronic Documents</a> E<sub>i</sub> obtained from an input <a>IMSC Document Instance</a>:</p>
+      <p>The HRM, illustrated in <a href="#fig-hypothetical-render-model"></a>, operates on a sequence of
+      <a>Intermediate Synchronic Documents</a> E<sub>i</sub> generated using the <i>Intermediate Synchronic Document
+      Construction</i> procedure specified in [[!TTML2]] from one or more input <a>IMSC Document Instances</a>:</p>
       <ul>
         <li><a>non-empty ISDs</a> are processed using a simple double buffering model: while a <a>non-empty ISD</a>
         E<sub>n</sub> is being painted into a Back Buffer, the previous <a>non-empty ISD</a> E<sub>m</sub> is available
@@ -475,7 +478,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
         <li>paint the text or image subtitle content.</li>
       </ol>
 
-      <p>The Presentation Compositor starts rendering E<sub>n</sub>:</p>
+      <p>The Presentation Compositor begins rendering E<sub>n</sub>:</p>
 
       <ul>
         <li>at the presentation time of E<sub>m</sub>, where m is the largest non-zero value that is both less than
@@ -545,7 +548,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p>It is an <a>error</a> for the Presentation Compositor to fail to complete painting pixels for
       <a>non-empty ISD</a> E<sub>n</sub> before its presentation time.</p>
 
-      <p>The following table specifies values for <a>IPD</a> and BDraw.</p>
+      <p>The following table specifies the values of <a>IPD</a> and BDraw.</p>
 
       <table class='simple'>
         <thead>
@@ -688,7 +691,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       <p>The size of Decoded Image Buffers D<sub>n</sub> or D<sub>n-1</sub> is the Normalized Decoded Image Buffer Size
       (NDIBS).</p>
 
-      <p>The following table specifies ICpy, IDec, and NDBIS.</p>
+      <p>The following table specifies the values of ICpy, IDec, and NDBIS.</p>
 
       <table class='simple'>
         <thead>
@@ -819,7 +822,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       typographical glyph aspect ratio. An implementation can determine an actual buffer size needs based on worst-case glyph size
       complexity.</p>
 
-      <p>The contents of the Glyph Buffer G<sub>n</sub> is copied instantaneously to Glyph Buffer G<sub>n-1</sub> at the
+      <p>The contents of the Glyph Buffer G<sub>n</sub> are copied instantaneously to Glyph Buffer G<sub>n-1</sub> at the
       presentation time of <a>Intermediate Synchronic Document</a> E<sub>n</sub>.</p>
 
       <p>It is an <a>error</a> for the sum of NRGA(g<sub>i</sub>) over all <a data-lt="glyph">glyphs</a> Glyph Buffer G<sub>n</sub>

--- a/spec/imsc-hrm.html
+++ b/spec/imsc-hrm.html
@@ -247,7 +247,7 @@ table.coldividers td + td { border-left:1px solid gray; text-align: center;}
       Given a sequence of consecutive <dfn data-cite="ttml2#terms-intermediate-synchronic-document">Intermediate
       Synchronic Documents</dfn> generated using the <i>Intermediate Synchronic Document Construction</i> procedure
       specified in [[!TTML2]] from one or more input <a>IMSC Document Instances</a>, the sequence of
-      <dfn>Intermediate Synchronic Documents</dfn> <i>conforms to the Hypothetical Render Model</i> SHALL be processed
+      <a>Intermediate Synchronic Documents</a> <i>conforms to the Hypothetical Render Model</i> SHALL be processed
       without <a>error</a> by the HRM algorithm specified at <a href="#hypothetical-render-model-general"></a>.
     </p>
     <p class="note">Applying the Hypothetical Render Model to a <a>Document Instance</a> that is not an <a>IMSC Document


### PR DESCRIPTION
The intent of these proposed changes is to clarify that the IMSC HRM specifies a document conformance regime, without imposing requirements on implementations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/pull/60.html" title="Last updated on Jan 10, 2023, 4:58 PM UTC (98a55a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc-hrm/60/f923e85...98a55a9.html" title="Last updated on Jan 10, 2023, 4:58 PM UTC (98a55a9)">Diff</a>