### PR TITLE
Updated GHAction for CRD

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -21,7 +21,7 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-tt/2021Oct/0005.html
           W3C_BUILD_OVERRIDE: |
-            specStatus: WD
+            specStatus: CRD
 
 # not set 'warning' to BUILD_FAIL_ON (not to cause error by bikeshed warning?)
 


### PR DESCRIPTION
This PR updates GHAction for streamlined publication, to be published as CRD. (draft status after CR publication.)

Do not merge this before CR publication. (fine to be merged after 2023-06-23, if publication out at 2023-06-22)